### PR TITLE
Render cursor at selection head

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -37,9 +37,10 @@ export class Cursor {
     }px)`;
   }
 
-  repositionToViewAnchor(view: EditorView) {
-    // If you do an all selection, the anchor gets set to 0...for some reason :/
-    const coords = view.coordsAtPos(Math.max(view.state.selection.anchor, 1));
+  repositionToViewHead(view: EditorView) {
+    // Note: If you do an all selection, the anchor gets set to the last position in the document
+    // which may be a location after the last block, so we reposition it to a location inside the last text block
+    const coords = view.coordsAtPos(Math.min(view.state.selection.head, view.state.doc.nodeSize - 3));
     this.reposition(coords.right, coords.top);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const view = new EditorView<typeof schema>(main, {
     this.updateState(newState);
 
     cursor.resetTimeout();
-    cursor.repositionToViewAnchor(this);
+    cursor.repositionToViewHead(this);
   },
 });
 
@@ -49,9 +49,9 @@ view.root.addEventListener("focus", () => cursor.resetTimeout(), true);
 view.root.addEventListener("blur", () => cursor.deactivate(), true);
 
 window.addEventListener("resize", () => {
-  cursor.repositionToViewAnchor(view);
+  cursor.repositionToViewHead(view);
 });
 
 view.focus();
 
-cursor.repositionToViewAnchor(view);
+cursor.repositionToViewHead(view);


### PR DESCRIPTION
Most editors show the cursor at the head of the selection rather than the anchor (Sublime Text, VS Code, Ace, etc).

I understand that it feels a bit janky while making large selections since the selection is not animated, so I would suggest that the transition of the cursor head is removed while making a selection somehow...